### PR TITLE
Fix returned error when deleting data from Redis failed

### DIFF
--- a/app/controllers/auth_controller.go
+++ b/app/controllers/auth_controller.go
@@ -255,7 +255,7 @@ func UserSignOut(c *fiber.Ctx) error {
 		// Return status 500 and Redis connection error.
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": true,
-			"msg":   err.Error(),
+			"msg":   errDelFromRedis.Error(),
 		})
 	}
 

--- a/app/controllers/auth_controller.go
+++ b/app/controllers/auth_controller.go
@@ -252,7 +252,7 @@ func UserSignOut(c *fiber.Ctx) error {
 	// Save refresh token to Redis.
 	errDelFromRedis := connRedis.Del(context.Background(), userID).Err()
 	if errDelFromRedis != nil {
-		// Return status 500 and Redis connection error.
+		// Return status 500 and Redis deletion error.
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": true,
 			"msg":   errDelFromRedis.Error(),


### PR DESCRIPTION
Return the deletion error message instead of the one from creating a new Redis connection.

Additionally, the `err` at `"msg": err.Error(),` might be `nil` at this point.