### PR TITLE
Change Handler to HandlerDefault

### DIFF
--- a/pkg/routes/swagger_route.go
+++ b/pkg/routes/swagger_route.go
@@ -12,5 +12,5 @@ func SwaggerRoute(a *fiber.App) {
 	route := a.Group("/swagger")
 
 	// Routes for GET method:
-	route.Get("*", swagger.Handler) // get one user by ID
+	route.Get("*", swagger.HandlerDefault) // get one user by ID
 }


### PR DESCRIPTION



**What this PR is changing or adding?**

Got a go compile error caused by `swagger.Handler` does not exist. After some investigation, `Handler` is now changed to `HandlerDefault`

refer here: https://github.com/arsmn/fiber-swagger/commit/cef3d9a463eb34d8f17d07e4548a8231c78cdac8

**Which issues are fixed by this PR?**

1. Got a compile error caused by `swagger.Handler` does not exist. 

## Pre-launch Checklist

- [ ] I have read and fully accepted project's [code of conduct](https://github.com/create-go-app/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation and/or comments to the code.
- [ ] All existing and new tests are passing successfully.
