### PR TITLE
fix @BasePath position.

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,10 +23,10 @@ import (
 // @contact.email your@mail.com
 // @license.name Apache 2.0
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+// @BasePath /api
 // @securityDefinitions.apikey ApiKeyAuth
 // @in header
 // @name Authorization
-// @BasePath /api
 func main() {
 	// Define Fiber config.
 	config := configs.FiberConfig()


### PR DESCRIPTION

`@BasePath` have to set above `@securityDefinitions.apikey` in order to apply value to `docs.go` when do `$ swag init`
Tested with 
- swag version `v1.8.1` 
( probably v1.8.2 because there is an [issue](https://github.com/swaggo/swag/issues/1207) mentions  wrong version when `swag -v`)
- go version `go1.18.2 linux/amd64`

**Before/after or any other screenshots**
**Before**
![image](https://user-images.githubusercontent.com/1501022/171677435-a52a4382-15e8-4603-a364-c6f74b1bc287.png)
**After**
![image](https://user-images.githubusercontent.com/1501022/171677591-5c312dfb-5331-4d53-847d-94c6c9b0d4b0.png)

**Which issues are fixed by this PR?**

1. This PR fixes when `$ swag init`, `@BasePath` value didn't got recognize by swag. Cause `docs/docs.go` have wrong value of `BasePath`

## Pre-launch Checklist

- [x] I have read and fully accepted project's [code of conduct](https://github.com/create-go-app/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation and/or comments to the code.
- [x] All existing and new tests are passing successfully.
