### PR TITLE
Use Select instead of Get for fetching a slice of results

### DIFF
--- a/app/queries/book_query.go
+++ b/app/queries/book_query.go
@@ -20,7 +20,7 @@ func (q *BookQueries) GetBooks() ([]models.Book, error) {
 	query := `SELECT * FROM books`
 
 	// Send query to database.
-	err := q.Get(&books, query)
+	err := q.Select(&books, query)
 	if err != nil {
 		// Return empty object and error.
 		return books, err


### PR DESCRIPTION
**Fixing a query bug for fetching all books**
Get is useful for fetching a single result and scanning it, and Select is useful for fetching a slice of results.
Since our `GetBooks()` is for fetching all rows so instead of `q.Get(&books, query)` we need to change this query to `q.Select(&books, query)`