### PR TITLE
fix golang version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine AS builder
+FROM golang:1.19-alpine AS builder
 
 LABEL maintainer="Vic Shóstak <vic@shostak.dev> (https://shostak.dev/)"
 


### PR DESCRIPTION
**What this PR is changing or adding?**
`github.com/rivo/uniseg v0.4.4 // indirect` module needs go1.18+, so I change golang image version from 1.17 to 1.19 in Dockerfile.


**Which issues are fixed by this PR?**

close #200 

1. <!-- Type `#` to choose from existing issues on this repository. -->

## Pre-launch Checklist

- [x] I have read and fully accepted project's [code of conduct](https://github.com/create-go-app/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation and/or comments to the code.
- [x] All existing and new tests are passing successfully.
