### PR TITLE
Fix key for claims

### DIFF
--- a/pkg/utils/jwt_generator.go
+++ b/pkg/utils/jwt_generator.go
@@ -52,7 +52,7 @@ func generateNewAccessToken(id string, credentials []string) (string, error) {
 
 	// Set public claims:
 	claims["id"] = id
-	claims["expires"] = time.Now().Add(time.Minute * time.Duration(minutesCount)).Unix()
+	claims["exp"] = time.Now().Add(time.Minute * time.Duration(minutesCount)).Unix()
 	claims["book:create"] = false
 	claims["book:update"] = false
 	claims["book:delete"] = false

--- a/pkg/utils/jwt_parser.go
+++ b/pkg/utils/jwt_parser.go
@@ -33,7 +33,7 @@ func ExtractTokenMetadata(c *fiber.Ctx) (*TokenMetadata, error) {
 		}
 
 		// Expires time.
-		expires := int64(claims["expires"].(float64))
+		expires := int64(claims["exp"].(float64))
 
 		// User credentials.
 		credentials := map[string]bool{


### PR DESCRIPTION
**What this PR is changing or adding?**

Corrects the JWT expiration key in claims from `expires` to `exp`, aligning it with standard JWT claim specifications.
See the GetExpirationTime function in [jwt/map_claims.go](https://github.com/golang-jwt/jwt/blob/5ec246c074b71790eec1f2e05b54daf6ec29ec5f/map_claims.go#L14)

**Before/after or any other screenshots**

<!-- Consider including before/after screenshots. -->

**Which issues are fixed by this PR?**

<!-- List which issues are fixed by this PR. You must list at least one issue. -->

1. #247 

## Pre-launch Checklist

- [x] I have read and fully accepted project's [code of conduct](https://github.com/create-go-app/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation and/or comments to the code.
- [x] All existing and new tests are passing successfully.
